### PR TITLE
Check availability before conditionals

### DIFF
--- a/librespot/audio/__init__.py
+++ b/librespot/audio/__init__.py
@@ -177,8 +177,8 @@ class AbsChunkedInputStream(io.BytesIO, HaltListener):
         if chunk_end > self.size():
             chunk_end = int(self.size() / (128 * 1024))
             chunk_end_off = int(self.size() % (128 * 1024))
+        self.check_availability(chunk, True, False)
         if chunk_off + __size > len(self.buffer()[chunk]):
-            self.check_availability(chunk, True, False)
             buffer.write(self.buffer()[chunk][chunk_off:])
             chunk += 1
             while chunk <= chunk_end:
@@ -189,7 +189,6 @@ class AbsChunkedInputStream(io.BytesIO, HaltListener):
                     buffer.write(self.buffer()[chunk])
                 chunk += 1
         else:
-            self.check_availability(chunk, True, False)
             buffer.write(self.buffer()[chunk][chunk_off:chunk_off + __size])
         buffer.seek(0)
         self.__pos += buffer.getbuffer().nbytes


### PR DESCRIPTION
While using `librespot-python` library I encountered a bug while reading from a stream.
```python
buffer = io.BytesIO()
chunk = int(self.__pos / (128 * 1024))
chunk_off = int(self.__pos % (128 * 1024))
chunk_end = int(__size / (128 * 1024))
chunk_end_off = int(__size % (128 * 1024))
...
if chunk_off + __size > len(self.buffer()[chunk]): # culprit
    self.check_availability(chunk, True, False)
    buffer.write(self.buffer()[chunk][chunk_off:])
    chunk += 1
    while chunk <= chunk_end:
        self.check_availability(chunk, True, False)
        if chunk == chunk_end:
            buffer.write(self.buffer()[chunk][:chunk_end_off])
        else:
            buffer.write(self.buffer()[chunk])
        chunk += 1
else:
    self.check_availability(chunk, True, False)
    buffer.write(self.buffer()[chunk][chunk_off:chunk_off + __size])
```

When we are loading the last bytes of the current chunk byte-array `self.buffer()[chunk]`, on the next iteration we will try to access `self.buffer()[chunk+1]` which is not loaded yet i.e. `len(self.buffer()[chunk+1]) == 0`.

![image](https://user-images.githubusercontent.com/8620461/157594150-b995fccb-14c6-4076-9110-78b8e02e95dc.png)

This causes `if chunk_off + __size > len(self.buffer()[chunk])` statement **to always resolve to `True`** which then **writes an entire `self.buffer()[chunk+1]` into the buffer** as opposed to writing only requested part of it of `__size`.


Therefore, I moved `self.check_availability(chunk, True, False)` to the top, so that `len(self.buffer()[chunk+1])` gets loaded before these conditional checks get executed.

Then, `len(self.buffer()[chunk+1]) > 0` and the conditional logic works as expected.

Let me know if you need any further clarifications.

I don't foresee any risks with this PR, since we call `self.check_availability(chunk, True, False)` after these checks in any case.