### PR TITLE
Add CDN exclusion for audio-gm-fb

### DIFF
--- a/librespot/audio/__init__.py
+++ b/librespot/audio/__init__.py
@@ -321,7 +321,7 @@ class CdnFeedHelper:
     @staticmethod
     def get_url(resp: StorageResolve.StorageResolveResponse) -> str:
         selected_url = random.choice(resp.cdnurl)
-        while "audio4-gm-fb" in selected_url:
+        while "audio4-gm-fb" in selected_url or "audio-gm-fb" in selected_url:
             selected_url = random.choice(resp.cdnurl)
         return selected_url
 


### PR DESCRIPTION
audio-gm-fb also has same issue as audio4-gm-fb regarding misconfigured certificate so adding the exclusion here also.