### PR TITLE
requirements.txt: Set versions as minimum instead of hardcoding as exact 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-defusedxml==0.7.1
-protobuf==3.20.1
-pycryptodomex==3.21.0
-pyogg==0.6.14a.1
-requests==2.32.3
-websocket-client==1.8.0
-zeroconf==0.136.0
+defusedxml>=0.7.1
+protobuf>=3.20.1
+pycryptodomex>=3.21.0
+pyogg>=0.6.14a.1
+requests>=2.32.3
+websocket-client>=1.8.0
+zeroconf>=0.136.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 defusedxml>=0.7.1
-protobuf>=3.20.1
+protobuf==3.20.1
 pycryptodomex>=3.21.0
 pyogg>=0.6.14a.1
 requests>=2.32.3


### PR DESCRIPTION
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
librespot 0.0.9 requires requests==2.30.0, but you have requests 2.32.3 which is incompatible.
```

If there turns out to be an issue later, it can be hardcoded [as minimum + maximum](https://stackoverflow.com/a/8811418).

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
librespot 0.0.9 requires requests==2.30.0, but you have requests 2.32.3 which is incompatible.
```

The way it is set at the moment breaks installing the project if newer versions need to be installed.