### PR TITLE
Fix issue with closing session (#200)

### DIFF
--- a/librespot/crypto.py
+++ b/librespot/crypto.py
@@ -65,7 +65,7 @@ class CipherPair:
             if mac != expected_mac:
                 raise RuntimeError()
             return Packet(cmd, payload_bytes)
-        except IndexError:
+        except (IndexError, OSError):
             raise RuntimeError("Failed to receive packet")
 
 


### PR DESCRIPTION
I was getting the following error after calling Session.close():

```
Exception in thread session-packet-receiver:
Traceback (most recent call last):
  File "librespot-python/librespot/crypto.py", line 58, in receive_encoded
    header_bytes = self.__receive_cipher.decrypt(connection.read(3))
                                                 ~~~~~~~~~~~~~~~^^^
  File "librespot-python/librespot/core.py", line 1889, in read
    return self.__socket.recv(length)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^
OSError: [Errno 9] Bad file descriptor
```

Adding `OSError` to the try/except in `CipherPair.receive_encoded` fixes this issue, making `CipherPair` raise a `RuntimeError` instead, which is properly handled by `Receiver`.