### PR TITLE
Accept Incorrectly Capitalized Content-Range Headers as Backup

### DIFF
--- a/librespot/audio/__init__.py
+++ b/librespot/audio/__init__.py
@@ -579,6 +579,8 @@ class CdnManager:
                                     range_end=ChannelManager.chunk_size - 1)
             content_range = response.headers.get("Content-Range")
             if content_range is None:
+                content_range = response.headers.get("content-range")
+            if content_range is None:
                 raise IOError("Missing Content-Range header!")
             split = content_range.split("/")
             self.size = int(split[1])


### PR DESCRIPTION
Some external podcast urls return a valid CDN response, which is not accepted due to the "Content-Range" header being all lowercase as "content-range". This tries the lowercase version of the header as a backup if no Content-Range header is found initially.