### PR TITLE
Support Rust librespot credential format in stored_file()

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ session = Session.Builder() \
     .create()
 ```
 
+### Use Stored Credentials for Login
+
+```python
+from librespot.core import Session
+
+# Supports both Python and Rust librespot credential formats
+
+session = Session.Builder() \
+    .stored_file("/path/to/credentials.json") \
+    .create()
+```
+
 ### Get Spotify's OAuth token
 
 ```python

--- a/librespot/core.py
+++ b/librespot/core.py
@@ -1618,6 +1618,7 @@ class Session(Closeable, MessageListener, SubListener):
                     pass
                 else:
                     try:
+                        # Try Python librespot format first
                         self.login_credentials = Authentication.LoginCredentials(
                             typ=Authentication.AuthenticationType.Value(
                                 obj["type"]),
@@ -1625,7 +1626,15 @@ class Session(Closeable, MessageListener, SubListener):
                             auth_data=base64.b64decode(obj["credentials"]),
                         )
                     except KeyError:
-                        pass
+                        # Try Rust librespot format (auth_type as int, auth_data instead of credentials)
+                        try:
+                            self.login_credentials = Authentication.LoginCredentials(
+                                typ=obj["auth_type"],
+                                username=obj["username"],
+                                auth_data=base64.b64decode(obj["auth_data"]),
+                            )
+                        except KeyError:
+                            pass
             return self
 
         def oauth(self, oauth_url_callback) -> Session.Builder:


### PR DESCRIPTION
Adds fallback logic to load credentials from Rust librespot's OAuth flow. The stored_file() method now handles both Python and Rust credential formats.

Related to #277