### PR TITLE
Support Rust and Python librespot credential formats

### DIFF
--- a/librespot/core.py
+++ b/librespot/core.py
@@ -1583,12 +1583,12 @@ class Session(Closeable, MessageListener, SubListener):
             else:
                 try:
                     self.login_credentials = Authentication.LoginCredentials(
-                        typ=Authentication.AuthenticationType.Value(
-                            obj["type"]),
+                        typ=obj.get("auth_type") or Authentication.AuthenticationType.Value(obj["type"]),
                         username=obj["username"],
-                        auth_data=base64.b64decode(obj["credentials"]),
+                        auth_data=base64.b64decode(obj.get("auth_data") or obj["credentials"]),
                     )
-                except KeyError:
+                except KeyError as e:
+                    self.logger.error("The stored credentials must contains these keys: username, auth_type or type, auth_data or credentials")
                     pass
             return self
 
@@ -1610,23 +1610,14 @@ class Session(Closeable, MessageListener, SubListener):
                     pass
                 else:
                     try:
-                        # Try Python librespot format first
                         self.login_credentials = Authentication.LoginCredentials(
-                            typ=Authentication.AuthenticationType.Value(
-                                obj["type"]),
+                            typ=obj.get("auth_type") or Authentication.AuthenticationType.Value(obj["type"]),
                             username=obj["username"],
-                            auth_data=base64.b64decode(obj["credentials"]),
+                            auth_data=base64.b64decode(obj.get("auth_data") or obj["credentials"]),
                         )
                     except KeyError:
-                        # Try Rust librespot format (auth_type as int, auth_data instead of credentials)
-                        try:
-                            self.login_credentials = Authentication.LoginCredentials(
-                                typ=obj["auth_type"],
-                                username=obj["username"],
-                                auth_data=base64.b64decode(obj["auth_data"]),
-                            )
-                        except KeyError:
-                            pass
+                        self.logger.error("The stored credentials must contains these keys: username, auth_type or type, auth_data or credentials")
+                        pass
             return self
 
         def oauth(self, oauth_url_callback, success_page_content = None) -> Session.Builder:


### PR DESCRIPTION
change how stored_file() method handle format difference between Rust and Python style.
 - reduce code duplication and error handling
 - resilient in case of mixing or having all keywords from both style
 
 add same behavior to stored() method
 
Related to #314 #277 